### PR TITLE
Support for unmodded PS2 controllers

### DIFF
--- a/Demos/ConsoleExample/Linux/Makefile
+++ b/Demos/ConsoleExample/Linux/Makefile
@@ -4,7 +4,8 @@ VPATH    =  .. \
 
 CPPFLAGS =  -I.. \
 			-I../../../ \
-			-I/usr/local/include/hidapi
+			-I/usr/local/include/hidapi \
+			-I/usr/include/hidapi
 
 LIBS     =    -lhidapi-libusb
 

--- a/Demos/ConsoleExample/consoleExample.cpp
+++ b/Demos/ConsoleExample/consoleExample.cpp
@@ -69,7 +69,7 @@ main(int argc, char** argv) {
   try {
 
     if (!usePullMode) {
-       gt = GameTrak::create(argc>1?argv[1]:"") ;
+       gt = GameTrak::create(argc>1?argv[1]:"any:?debugLevel=1&ps2mode=true") ;
        gt->setGameTrakCallback(GameTrakCallback) ;
     } else {
        gt = GameTrak::create(argc>1?argv[1]:"any:?pullMode=true") ;

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [Wikipedia](http://en.wikipedia.org/wiki/Gametrak) [Review](http://cb.nowan.net/blog/2006/09/25/gametrak-a-first-impression/) [Music](http://www.youtube.com/watch?v=HFfR_9Wczjc) [Research project using the Gametrak](http://www.youtube.com/watch?v=ZxJD9DXDB1E)
 
 ## Features
-* Cross-platform library based on [HIDAPI](http://www.signal11.us/oss/hidapi/) to get raw events from the Gametrak (first you need to install a fresh version of HIDAPI from [here](https://github.com/signal11/hidapi))
-* Inspired by [Libpointing](http://www.libpointing.org/)
+* Cross-platform library based on [HIDAPI](https://github.com/libusb/hidapi) to get raw events from the Gametrak (first you need to install a fresh version of HIDAPI from [here](https://github.com/libusb/hidapi))
+* Inspired by [Libpointing](https://github.com/INRIA/libpointing)
 * Get the position of each string end in Cartesian coordinates using metric units (mm)
 * Use callback functions instead of pooling
 * [1€](http://cristal.univ-lille.fr/~casiez/1euro/) filter embedded
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 ```
 
 ## Installation
-1. Install [HIDAPI](https://github.com/signal11/hidapi) for your platform (on macOS, you can use `brew install hidapi`)
+1. Install [HIDAPI](https://github.com/libusb/hidapi) for your platform (on macOS, you can use `brew install hidapi`)
 1. Compile the libgametrak library, using the ```make``` command in the folder corresponding to your platform (e.g. [installation/OSX](installation/OSX) for macOS). You'll find the compiled library in the ```installation``` folder.
 1. Test the library using [ConsoleExample](Demos/ConsoleExample/) (e.g. run ```make``` in the [Demos/ConsoleExample/OSX](Demos/ConsoleExample/OSX) folder for macOS)
 1. Run the example using ```./main``` in the corresponding platform folder
@@ -108,7 +108,7 @@ The uri "" sets all parameters to default
 ## Installation
 Works on Windows, OS X, Linux
 
-There is no driver to install, simply install the last version of [HIDAPI](https://github.com/signal11/hidapi)
+There is no driver to install, simply install the last version of [HIDAPI](https://github.com/libusb/hidapi)
 
 ## Frame of reference
 The picture below illustrates the origin and the axis used to locate each Gametrak pointer. 

--- a/libgametrak/HIDAPIGameTrak.h
+++ b/libgametrak/HIDAPIGameTrak.h
@@ -38,14 +38,17 @@ namespace gametrak {
     bool run; // for the Loop thread
 
     bool pictrak; // Jan Ciger Pictrak board
+    bool ps2mode;
+    unsigned int ps2key;
+    unsigned char ps2index;
     std::string serial_number;
 
     bool threadFinished;
 
 #ifdef WIN32
-  HANDLE hThreads[1];
-  DWORD dwThreadId;
-  DWORD dwThreadParam;
+    HANDLE hThreads[1];
+    DWORD dwThreadId;
+    DWORD dwThreadParam;
 #else
     pthread_t thread ;
 #endif
@@ -56,7 +59,9 @@ namespace gametrak {
       rawRightThetafPrev, rawRightPhifPrev, rawRightLfPrev;
 
     void connect();
-		void disconnect();
+    void disconnect();
+    void ps2Init(bool reset);
+    void ps2NextKey();
 
     volatile bool deviceConnected;
 
@@ -66,7 +71,7 @@ namespace gametrak {
 
     URI getURI(bool expanded=false) const ;
 #ifdef WIN32
-	static DWORD WINAPI eventloop(LPVOID lpvThreadParam);
+    static DWORD WINAPI eventloop(LPVOID lpvThreadParam);
 #else
     static void *eventloop(void *self) ;
 #endif


### PR DESCRIPTION
The PS2 versions do not transmit data unless they receive a special SET_REPORT request every 2 to 255 reports.
This patch calculates the required value and sends the request every 100 reports.
It only took 20 years, but hardware modifications are no longer necessary.
Tested only on Linux. Windows tends to interfere with SET_REPORT requests.
